### PR TITLE
Added expiration jwt/cookie to password reset and added Error handling

### DIFF
--- a/components/forgotPasswordForm.tsx
+++ b/components/forgotPasswordForm.tsx
@@ -1,10 +1,11 @@
 import { Box, Input, Text, Button, FormLabel } from '@chakra-ui/react'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 export const ForgotPasswordForm = () => {
   const [email, setEmail] = useState('')
   const [success, setSuccess] = useState(false)
+  const [error, setError] = useState(false)
   const router = useRouter()
 
   const mailObj = {
@@ -21,11 +22,17 @@ export const ForgotPasswordForm = () => {
         'Content-Type': 'application/json',
       },
     }).then((res) => {
-      setEmail('')
-      setSuccess(true)
-      setTimeout(() => {
-        router.push('/signin')
-      }, 3000)
+      console.log(res.status)
+      if (res.status === 401) {
+        setError(true)
+        console.log(error)
+      } else {
+        setEmail('')
+        setSuccess(true)
+        setTimeout(() => {
+          router.push('/signin')
+        }, 3000)
+      }
     })
   }
 
@@ -46,6 +53,7 @@ export const ForgotPasswordForm = () => {
             <Input type="email" onChange={(e) => setEmail(e.target.value)} />
             <Button type="submit">Reset Password</Button>
           </form>
+          {error && <Text>Error! User not found!</Text>}
         </Box>
       )}
     </>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken'
+import cookie from 'cookie'
 import { NextApiRequest, NextApiResponse } from 'next'
 import prisma from './prisma'
 
@@ -29,6 +30,17 @@ export const validateRoute = (handler) => {
           throw new Error('User not found')
         }
       } catch (e) {
+        res.setHeader(
+          'Set-Cookie',
+          await cookie.serialize('MINDFULLY_FULL_ACCESS_TOKEN', null, {
+            httpOnly: true,
+            maxAge: -1,
+            path: '/',
+            sameSite: 'lax',
+            secure: process.env.NODE_ENV === 'production',
+          })
+        )
+        console.log('CATCH unauthourized user')
         res.status(401).json({ e: e.message })
         return
       }

--- a/pages/user-help/[userEmail]/[resetToken].tsx
+++ b/pages/user-help/[userEmail]/[resetToken].tsx
@@ -1,10 +1,12 @@
 import { Box, Button, Input, FormLabel } from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
+import { Text } from '@chakra-ui/react'
 
 const ForgotPassword = () => {
   const [email, setEmail] = useState('')
   const [newPassword, setNewPassword] = useState('')
+  const [error, setError] = useState(false)
   const router = useRouter()
 
   const handleResetPassword = async (e) => {
@@ -19,8 +21,14 @@ const ForgotPassword = () => {
       headers: {
         'Content-Type': 'application/json',
       },
+    }).then((res) => {
+      if (res.status === 401) {
+        setError(true)
+      } else {
+        router.push('/signin')
+      }
     })
-    router.push('/')
+    // .catch((error) => console.log(error))
   }
 
   useEffect(() => {
@@ -39,6 +47,7 @@ const ForgotPassword = () => {
         />
         <Button type="submit">Change Password</Button>
       </form>
+      {error && <Text>Unauthourized Request!</Text>}
     </Box>
   )
 }


### PR DESCRIPTION
Added an expiration date for the password reset functionality. A cookie & a jwt are added when the user submits an email address that exists within our database. A link to the page where the password can be changed is then send to the user's email. After 10 minutes the cookie expires and the password can no longer be changed. Added basic error handling to this function as well.